### PR TITLE
Issue 12 stopping criteria bb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/bin/
+=======
 # Created by .ignore support plugin (hsz.mobi)
 ### Scala template
 *.class
@@ -17,4 +19,3 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
-

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object ProjectBuild extends Build {
     base = file("."),
     settings = Project.defaultSettings ++ Seq(
       	name := "spark-MDLP-discretization",
-	version := "0.2",
+	version := "0.2-SNAPSHOT",
 	organization := "org.apache.spark",
 	scalaVersion := "2.11.6",
 	spName := "apache/spark-MDLP-discretization",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object ProjectBuild extends Build {
     settings = Project.defaultSettings ++ Seq(
       	name := "spark-MDLP-discretization",
 	version := "0.2",
-	organization := "org.apache",
+	organization := "org.apache.spark",
 	scalaVersion := "2.11.6",
 	spName := "apache/spark-MDLP-discretization",
 	sparkVersion := "1.6.2",

--- a/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
@@ -162,7 +162,7 @@ class DiscretizerModel private[ml] (
   /**
    * Transform a vector to the discrete space determined by the splits.
    * NOTE: Vectors to be transformed must be the same length
-   * as the source vectors given to [[MDLPDiscretizer.fit]].
+   * as the source vectors given to MDLPDiscretizer.fit.
    */
   override def transform(dataset: DataFrame): DataFrame = {
     transformSchema(dataset.schema, logging = true)

--- a/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
@@ -39,8 +39,8 @@ private[feature] trait MDLPDiscretizerParams extends Params with HasInputCol wit
   /**
    * Maximum number of buckets into which data points are grouped. 
    * Must be >= 2. default: 2
-    *
-    * @group param
+   *
+   * @group param
    */
   val maxBins = new IntParam(this, "maxBins", "Maximum number of bins" +
     "into which data points are grouped. Must be >= 2.",
@@ -65,6 +65,16 @@ private[feature] trait MDLPDiscretizerParams extends Params with HasInputCol wit
   /** @group getParam */
   def getMaxByPart: Int = getOrDefault(maxByPart)
 
+  val stoppingCriterion = new DoubleParam(this, "stoppingCriterion",
+    "The minimum description length principal (MDLP) stopping criterion. " +
+    "The default is 0 to match what was suggested in the original 1993 paper by Fayyad and Irani. " +
+    "However, smaller values (like -1e-4 or -1e-2) can be set in order to " +
+    "relax the constraint and produce more splits.",
+     ParamValidators.ltEq(0))
+  setDefault(stoppingCriterion -> 0)
+
+  /** @group getParam */
+  def getStoppingCriterion: Double = getOrDefault(stoppingCriterion)
 }
 
 /**
@@ -84,6 +94,9 @@ class MDLPDiscretizer (override val uid: String) extends Estimator[DiscretizerMo
   def setMaxByPart(value: Int): this.type = set(maxByPart, value)
 
   /** @group setParam */
+  def setStoppingCriterion(value: Double): this.type = set(stoppingCriterion, value)
+
+  /** @group setParam */
   def setInputCol(value: String): this.type = set(inputCol, value)
 
   /** @group setParam */
@@ -101,7 +114,7 @@ class MDLPDiscretizer (override val uid: String) extends Estimator[DiscretizerMo
       case Row(label: Double, features: Vector) =>
         LabeledPoint(label, features)
     }
-    val discretizer = feature.MDLPDiscretizer.train(input, None, $(maxBins), $(maxByPart))
+    val discretizer = feature.MDLPDiscretizer.train(input, None, $(maxBins), $(maxByPart), $(stoppingCriterion))
     copyValues(new DiscretizerModel(uid, discretizer.thresholds).setParent(this))
   }
   

--- a/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
@@ -104,27 +104,6 @@ class MDLPDiscretizer (override val uid: String) extends Estimator[DiscretizerMo
     val discretizer = feature.MDLPDiscretizer.train(input, None, $(maxBins), $(maxByPart))
     copyValues(new DiscretizerModel(uid, discretizer.thresholds).setParent(this))
   }
-
-  /**
-    * The bucketizers must have more than one bucket. So [-Inf, Inf] is replaced with [-Inf, 0, Inf].
-    * @return a sequence of Bucketizer that have been fit to the dataset
-    */
-  def fitToBucketizers(dataset: DataFrame): Seq[Bucketizer] = {
-    transformSchema(dataset.schema, logging = true)
-    val input = dataset.select($(labelCol), $(inputCol)).map {
-      case Row(label: Double, features: Vector) =>
-        LabeledPoint(label, features)
-    }
-    val discretizer = feature.MDLPDiscretizer.train(input, None, $(maxBins), $(maxByPart))
-
-    discretizer.thresholds.map(threshes => {
-      // The Bucketizer splits cannot have only a single bin, so 0 is added to satisfy that unfortunate requirement.
-      val splits = if (threshes.length > 2) threshes.map(_.toDouble)
-        else Array(Double.NegativeInfinity, 0.0, Double.PositiveInfinity)
-      val bucketizer = new Bucketizer(uid).setSplits(splits)
-      copyValues(bucketizer)
-    })
-  }
   
   override def transformSchema(schema: StructType): StructType = {
     validateParams()

--- a/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
@@ -53,13 +53,13 @@ private[feature] trait MDLPDiscretizerParams extends Params with HasInputCol wit
   /**
    * Maximum number of elements to evaluate in each partition. 
    * If this parameter is bigger then the evaluation phase will be sequentially performed. 
-   * Must be >= 10,000.
+   * Should be >= 10,000, but it is allowed to go as low as 100 for testing purposes.
    * default: 10,000
    * @group param
    */
   val maxByPart = new IntParam(this, "maxByPart", "Maximum number of elements per partition" +
-    "to considere in each evaluation process. Must be >= 10,000.",
-    ParamValidators.gtEq(10000))
+    "to consider in each evaluation process. Should be >= 10,000 (the default)",
+    ParamValidators.gtEq(100))
   setDefault(maxByPart -> 10000)
 
   /** @group getParam */

--- a/src/main/scala/org/apache/spark/mllib/feature/BucketInfo.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/BucketInfo.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.mllib.feature
+
+import FeatureUtils._
+
+/**
+  * @param totals frequency totals for unique values in the bucket
+  */
+class BucketInfo(totals: Array[Long]) extends Serializable {
+  // number of elements in bucket
+  val s = totals.sum
+
+  // calculated entropy for the bucket
+  val hs = entropy(totals.toSeq, s)
+
+  // number of distinct classes in bucket
+  val k = totals.count(_ != 0)
+}

--- a/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
@@ -28,6 +28,24 @@ import scala.collection.mutable
 @Experimental
 object FeatureUtils {
 
+
+  private val LOG2 = math.log(2)
+
+  /** @return log base 2 of x */
+  val log2 = { x: Double => math.log(x) / LOG2 }
+
+  /**
+    * @param frequencies sequence of integer frequencies.
+    * @param n the sum of all the frequencies in the list.
+    * @return the total entropy
+    */
+  def entropy(frequencies: Seq[Long], n: Long) = {
+    -frequencies.aggregate(0.0)(
+      { case (h, q) => h + (if (q == 0) 0 else (q.toDouble / n) * log2(q.toDouble / n))},
+      { case (h1, h2) => h1 + h2 }
+    )
+  }
+
   /**
    * Returns a vector with features filtered.
    * Preserves the order of filtered features the same as their indices are stored.

--- a/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
@@ -28,6 +28,24 @@ import scala.collection.mutable
 @Experimental
 object FeatureUtils {
 
+
+  private val LOG2 = math.log(2)
+
+  /** @return log base 2 of x */
+  val log2 = { x: Double => math.log(x) / LOG2 }
+
+  /**
+    * @param freqs sequence of integer frequencies.
+    * @param n the sum of all the frequencies in the list.
+    * @return the total entropy
+    */
+  def entropy(freqs: Seq[Long], n: Long) = {
+    -freqs.aggregate(0.0)(
+      { case (h, q) => h + (if (q == 0) 0 else (q.toDouble / n) * log2(q.toDouble / n))},
+      { case (h1, h2) => h1 + h2 }
+    )
+  }
+
   /**
    * Returns a vector with features filtered.
    * Preserves the order of filtered features the same as their indices are stored.

--- a/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
@@ -28,24 +28,6 @@ import scala.collection.mutable
 @Experimental
 object FeatureUtils {
 
-
-  private val LOG2 = math.log(2)
-
-  /** @return log base 2 of x */
-  val log2 = { x: Double => math.log(x) / LOG2 }
-
-  /**
-    * @param freqs sequence of integer frequencies.
-    * @param n the sum of all the frequencies in the list.
-    * @return the total entropy
-    */
-  def entropy(freqs: Seq[Long], n: Long) = {
-    -freqs.aggregate(0.0)(
-      { case (h, q) => h + (if (q == 0) 0 else (q.toDouble / n) * log2(q.toDouble / n))},
-      { case (h1, h2) => h1 + h2 }
-    )
-  }
-
   /**
    * Returns a vector with features filtered.
    * Preserves the order of filtered features the same as their indices are stored.

--- a/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FeatureUtils.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.mllib.feature
 
-import scala.collection.mutable.ArrayBuilder
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.mllib.linalg._
 

--- a/src/main/scala/org/apache/spark/mllib/feature/FewValuesThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FewValuesThresholdFinder.scala
@@ -1,0 +1,109 @@
+package org.apache.spark.mllib.feature
+
+import org.apache.spark.Logging
+import org.apache.spark.mllib.feature.FeatureUtils._
+
+import scala.collection.mutable
+
+
+/**
+  * @param nLabels the number of class labels
+  * @param stoppingCriterion influences when to stop recursive splits
+  */
+class FewValuesThresholdFinder(nLabels: Int, stoppingCriterion: Double) extends Serializable with Logging {
+
+  /**
+    * Evaluates boundary points and selects the most relevant candidates (sequential version).
+    * Here, the evaluation is bounded by partition as the number of points is small enough.
+    *
+    * @param candidates RDD of candidates points (point, class histogram).
+    * @param maxBins Maximum number of points to select.
+    * @return Sequence of threshold values.
+    */
+  def findThresholds(candidates: Array[(Float, Array[Long])], maxBins: Int) = {
+
+    val stack = new mutable.Queue[((Float, Float), Option[Float])]
+    // Insert first in the stack (recursive iteration)
+    stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
+    var result = Seq(Float.NegativeInfinity) // # points = # bins - 1
+
+    while (stack.nonEmpty && result.size < maxBins){
+      val (bounds, lastThresh) = stack.dequeue
+      // Filter the candidates between the last limits added to the stack
+      val newCandidates = candidates.filter({ case (th, _) =>
+        th > bounds._1 && th < bounds._2
+      })
+      if (newCandidates.length > 0) {
+        evalThresholds(newCandidates, lastThresh, nLabels) match {
+          case Some(th) =>
+            result = th +: result
+            stack.enqueue(((bounds._1, th), Some(th)))
+            stack.enqueue(((th, bounds._2), Some(th)))
+          case None => /* criteria not fulfilled, finish */
+        }
+      }
+    }
+    result.sorted :+ Float.PositiveInfinity
+  }
+
+  /**
+    * Compute entropy minimization for candidate points in a range,
+    * and select the best one according to MDLP criterion (sequential version).
+    *
+    * @param candidates Array of candidate points (point, class histogram).
+    * @param lastSelected last selected threshold.
+    * @param nLabels Number of classes.
+    * @return The minimum-entropy cut point.
+    *
+    */
+  private def evalThresholds(candidates: Array[(Float, Array[Long])],
+                              lastSelected : Option[Float],
+                              nLabels: Int): Option[Float] = {
+
+    // Calculate the total frequencies by label
+    val totals = candidates.map(_._2).reduce((freq1, freq2) => (freq1, freq2).zipped.map(_ + _))
+
+    // Compute the accumulated frequencies (both left and right) by label
+    var leftAccum = Array.fill(nLabels)(0L)
+    var entropyFreqs = Seq.empty[(Float, Array[Long], Array[Long], Array[Long])]
+    for(i <- candidates.indices) {
+      val (cand, freq) = candidates(i)
+      leftAccum = (leftAccum, freq).zipped.map(_ + _)
+      val rightTotal = (totals, leftAccum).zipped.map(_ - _)
+      entropyFreqs = (cand, freq, leftAccum.clone, rightTotal) +: entropyFreqs
+    }
+
+    // calculate h(S)
+    // s: number of elements
+    // k: number of distinct classes
+    // hs: entropy
+    val s = totals.sum
+    val hs = entropy(totals.toSeq, s)
+    val k = totals.count(_ != 0)
+
+    // select best threshold according to the criteria
+    val finalCandidates = entropyFreqs.flatMap({
+      case (cand, _, leftFreqs, rightFreqs) =>
+        val k1 = leftFreqs.count(_ != 0)
+        val s1 = if (k1 > 0) leftFreqs.sum else 0
+        val hs1 = entropy(leftFreqs, s1)
+        val k2 = rightFreqs.count(_ != 0)
+        val s2 = if (k2 > 0) rightFreqs.sum else 0
+        val hs2 = entropy(rightFreqs, s2)
+        val weightedHs = (s1 * hs1 + s2 * hs2) / s
+        val gain = hs - weightedHs
+        val delta = log2(math.pow(3, k) - 2) - (k * hs - k1 * hs1 - k2 * hs2)
+        var criterion = (gain - (log2(s - 1) + delta) / s) > stoppingCriterion
+
+        lastSelected match {
+          case None =>
+          case Some(last) => criterion = criterion && (cand != last)
+        }
+
+        if (criterion) Seq((weightedHs, cand)) else Seq.empty[(Double, Float)]
+    })
+    // Select among the list of accepted candidate, that with the minimum weightedHs
+    if (finalCandidates.nonEmpty) Some(finalCandidates.min._2) else None
+  }
+
+}

--- a/src/main/scala/org/apache/spark/mllib/feature/FewValuesThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FewValuesThresholdFinder.scala
@@ -88,18 +88,12 @@ class FewValuesThresholdFinder(nLabels: Int, stoppingCriterion: Double)
       entropyFreqs = (cand, freq, leftAccum.clone, rightTotal) +: entropyFreqs
     }
 
-    // calculate h(S)
-    // s: number of elements
-    // k: number of distinct classes
-    // hs: entropy
-    val s = totals.sum
-    val hs = entropy(totals.toSeq, s)
-    val k = totals.count(_ != 0)
+    val bucketInfo = new BucketInfo(totals)
 
     // select best threshold according to the criteria
     val finalCandidates = entropyFreqs.flatMap({
       case (cand, _, leftFreqs, rightFreqs) =>
-        val (criterionValue, weightedHs) = calcCriterionValue(s, hs, k, leftFreqs, rightFreqs)
+        val (criterionValue, weightedHs) = calcCriterionValue(bucketInfo, leftFreqs, rightFreqs)
         var criterion = criterionValue > stoppingCriterion
 
         lastSelected match {

--- a/src/main/scala/org/apache/spark/mllib/feature/FewValuesThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/FewValuesThresholdFinder.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.mllib.feature
 
 import scala.collection.mutable

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -151,10 +151,9 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
     // Insert the extreme values in the stack (recursive iteration)
     val stack = new mutable.Queue[((Float, Float), Option[Float])]
     stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
-    var result = Seq(Float.NegativeInfinity)
-    val maxPoints = maxBins + 1
+    var result = Seq(Float.NegativeInfinity) // # points = # bins - 1
 
-    while(stack.nonEmpty && result.size < maxPoints){
+    while(stack.nonEmpty && result.size < maxBins){
       val (bounds, lastThresh) = stack.dequeue
       // Filter the candidates between the last limits added to the stack
       var cands = candidates.filter({ case (th, _) => th > bounds._1 && th < bounds._2 })
@@ -188,10 +187,9 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
     val stack = new mutable.Queue[((Float, Float), Option[Float])]
     // Insert first in the stack (recursive iteration)
     stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
-    var result = Seq(Float.NegativeInfinity)
-    val maxPoints = maxBins + 1
+    var result = Seq(Float.NegativeInfinity) // # points = # bins - 1
 
-    while(stack.nonEmpty && result.size < maxPoints){
+    while(stack.nonEmpty && result.size < maxBins){
       val (bounds, lastThresh) = stack.dequeue
       // Filter the candidates between the last limits added to the stack
       val newCandidates = candidates.filter({ case (th, _) => 

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -456,7 +456,6 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
     // Join all thresholds in a single structure
     val bigThRDD = sc.parallelize(bigThresholds.toSeq)
     val thrs = smallThresholds.union(bigThRDD).collect()
-    print("thresholds = " + thrs)
     
     // Update the full list features with the thresholds calculated
     val thresholds = Array.fill(nFeatures)(Array.empty[Float])   // Nominal values (empty)
@@ -466,6 +465,7 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
     thrs.foreach({case (k, vth) => 
       thresholds(k) = if (arr.length > 0) vth.toArray else Array(Float.PositiveInfinity)})
     logInfo("Number of features with thresholds computed: " + thrs.length)
+    println("thresholds = " + thresholds.map(_.mkString(", ")).mkString(";\n"))
     
     new DiscretizerModel(thresholds)
   }

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -465,7 +465,7 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
     thrs.foreach({case (k, vth) => 
       thresholds(k) = if (arr.length > 0) vth.toArray else Array(Float.PositiveInfinity)})
     logInfo("Number of features with thresholds computed: " + thrs.length)
-    println("thresholds = " + thresholds.map(_.mkString(", ")).mkString(";\n"))
+    logDebug("thresholds = " + thresholds.map(_.mkString(", ")).mkString(";\n"))
     
     new DiscretizerModel(thresholds)
   }

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -268,7 +268,6 @@ object MDLPDiscretizer {
    * @param maxByPart Maximum number of elements by partition.
    * @param stoppingCriterion the threshold used to determine when stop recursive splitting of buckets.
    * @return A DiscretizerModel with the subsequent thresholds.
-   * 
    */
   def train(
       input: RDD[LabeledPoint],

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -141,14 +141,14 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint],
         data.flatMap({ case LabeledPoint(label, dv: DenseVector) =>
             val c = Array.fill[Long](nLabels)(0L)
             c(bLabels2Int.value(label)) = 1L
-            for(i <- dv.values.indices) yield ((i, dv(i).toFloat), c)
+            for (i <- dv.values.indices) yield ((i, dv(i).toFloat), c)
         })
       case false =>
         sc.broadcast(continuousVars)
         data.flatMap{ case LabeledPoint(label, sv: SparseVector) =>
           val c = Array.fill[Long](nLabels)(0L)
           c(bLabels2Int.value(label)) = 1L
-          for(i <- sv.indices.indices) yield ((sv.indices(i), sv.values(i).toFloat), c)
+          for (i <- sv.indices.indices) yield ((sv.indices(i), sv.values(i).toFloat), c)
         }
     }
     

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable
 
 import breeze.linalg.{SparseVector => BSV}
 
-import org.apache.spark.SparkContext._ 
+import org.apache.spark.SparkContext._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.Logging
 import org.apache.spark.rdd._
@@ -220,7 +220,6 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
       candidates: RDD[(Float, Array[Long])],
       lastSelected : Option[Float]) = {
 
-    val numPartitions = candidates.partitions.length
     val sc = candidates.sparkContext
 
     // Compute the accumulated frequencies by partition
@@ -261,9 +260,11 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
     // select the best threshold according to MDLP
     val finalCandidates = result.flatMap({
       case (cand, _, leftFreqs, rightFreqs) =>
-        val k1 = leftFreqs.count(_ != 0); val s1 = leftFreqs.sum
+        val k1 = leftFreqs.count(_ != 0)
+        val s1 = leftFreqs.sum
         val hs1 = entropy(leftFreqs, s1)
-        val k2 = rightFreqs.count(_ != 0); val s2 = rightFreqs.sum
+        val k2 = rightFreqs.count(_ != 0)
+        val s2 = rightFreqs.sum
         val hs2 = entropy(rightFreqs, s2)
         val weightedHs = (s1 * hs1 + s2 * hs2) / s
         val gain = hs - weightedHs
@@ -343,7 +344,7 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint]) extends Serializable
   /**
    * Run the entropy minimization discretizer on input data.
    * 
-   * @param contFeat Indices to discretize (if not specified, the algorithm try to figure it out).
+   * @param contFeat Indices to discretize (if not specified, the algorithm tries to figure it out).
    * @param elementsByPart Maximum number of elements to keep in each partition.
    * @param maxBins Maximum number of thresholds per feature.
    * @return A discretization model with the thresholds by feature.

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -227,10 +227,10 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint],
     val finalCandidates = result.flatMap({
       case (cand, _, leftFreqs, rightFreqs) =>
         val k1 = leftFreqs.count(_ != 0)
-        val s1 = leftFreqs.sum
+        val s1 = if (k1 > 0) leftFreqs.sum else 0
         val hs1 = entropy(leftFreqs, s1)
         val k2 = rightFreqs.count(_ != 0)
-        val s2 = rightFreqs.sum
+        val s2 = if (k2 > 0) rightFreqs.sum else 0
         val hs2 = entropy(rightFreqs, s2)
         val weightedHs = (s1 * hs1 + s2 * hs2) / s
         val gain = hs - weightedHs

--- a/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/MDLPDiscretizer.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.mllib.feature
 
-import scala.collection.mutable
-
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.Logging
 import org.apache.spark.rdd._
@@ -96,217 +94,7 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint],
       }             
     })
   }
-  
-  /**
-   * Evaluate boundary points and select the most relevant. This version is used when 
-   * the number of candidates exceeds the maximum size per partition (distributed version).
-   * 
-   * @param candidates RDD of candidates points (point, class histogram).
-   * @param maxBins Maximum number of points to select
-   * @param elementsByPart Maximum number of elements to evaluate in each partition.
-   * @return Sequence of threshold values.
-   */
-  private def getThresholds(
-      candidates: RDD[(Float, Array[Long])],
-      maxBins: Int, 
-      elementsByPart: Int): Seq[Float] = {
 
-    // Get the number of partitions according to the maximum size established by partition
-    val partitions = { x: Long => math.ceil(x.toFloat / elementsByPart).toInt }    
-    
-    // Insert the extreme values in the stack (recursive iteration)
-    val stack = new mutable.Queue[((Float, Float), Option[Float])]
-    stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
-    var result = Seq(Float.NegativeInfinity) // # points = # bins - 1
-
-    while (stack.nonEmpty && result.size < maxBins){
-      val (bounds, lastThresh) = stack.dequeue
-      // Filter the candidates between the last limits added to the stack
-      var cands = candidates.filter({ case (th, _) => th > bounds._1 && th < bounds._2 })
-      val nCands = cands.count
-      if (nCands > 0) {
-        cands = cands.coalesce(partitions(nCands))
-        // Selects one threshold among the candidates and returns two partitions to recurse
-        evalThresholds(cands, lastThresh) match {
-          case Some(th) =>
-            result = th +: result
-            stack.enqueue(((bounds._1, th), Some(th)))
-            stack.enqueue(((th, bounds._2), Some(th)))
-          case None => /* criteria not fulfilled, finish! */
-        }
-      }
-    }
-
-    result.sorted :+ Float.PositiveInfinity
-  }
-  
-  /**
-   * Evaluates boundary points and selects the most relevant candidates (sequential version).
-   * Here, the evaluation is bounded by partition as the number of points is small enough.
-   * 
-   * @param candidates RDD of candidates points (point, class histogram).
-   * @param maxBins Maximum number of points to select.
-   * @return Sequence of threshold values.
-   */
-  private def getThresholds(candidates: Array[(Float, Array[Long])], maxBins: Int) = {
-
-    val stack = new mutable.Queue[((Float, Float), Option[Float])]
-    // Insert first in the stack (recursive iteration)
-    stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
-    var result = Seq(Float.NegativeInfinity) // # points = # bins - 1
-
-    while (stack.nonEmpty && result.size < maxBins){
-      val (bounds, lastThresh) = stack.dequeue
-      // Filter the candidates between the last limits added to the stack
-      val newCandidates = candidates.filter({ case (th, _) => 
-          th > bounds._1 && th < bounds._2 
-        })      
-      if (newCandidates.length > 0) {
-        evalThresholds(newCandidates, lastThresh, nLabels) match {
-          case Some(th) =>
-            result = th +: result
-            stack.enqueue(((bounds._1, th), Some(th)))
-            stack.enqueue(((th, bounds._2), Some(th)))
-          case None => /* criteria not fulfilled, finish */
-        }
-      }
-    }
-    result.sorted :+ Float.PositiveInfinity
-  }
-
-  /**
-   * Compute entropy minimization for candidate points in a range,
-   * and select the best one according to the MDLP criterion (RDD version).
-   * 
-   * @param candidates RDD of candidate points (point, class histogram).
-   * @param lastSelected Last selected threshold.
-   * @return The minimum-entropy candidate.
-   */
-  private def evalThresholds(
-      candidates: RDD[(Float, Array[Long])],
-      lastSelected : Option[Float]) = {
-
-    val sc = candidates.sparkContext
-
-    // Compute the accumulated frequencies by partition
-    val totalsByPart = sc.runJob(candidates, { case it =>
-      val accum = Array.fill(nLabels)(0L)
-      for ((_, freqs) <- it) {for (i <- 0 until nLabels) accum(i) += freqs(i)}
-      accum
-    }: (Iterator[(Float, Array[Long])]) => Array[Long])
-    
-    // Compute the total frequency for all partitions
-    var totals = Array.fill(nLabels)(0L)
-    for (t <- totalsByPart) totals = (totals, t).zipped.map(_ + _)
-    val bcTotalsByPart = sc.broadcast(totalsByPart)
-    val bcTotals = sc.broadcast(totals)
-
-    val result = candidates.mapPartitionsWithIndex({ (slice, it) =>
-      // Accumulate frequencies from the left to the current partition
-      var leftTotal = Array.fill(nLabels)(0L)
-      for (i <- 0 until slice) leftTotal = (leftTotal, bcTotalsByPart.value(i)).zipped.map(_ + _)
-      var entropyFreqs = Seq.empty[(Float, Array[Long], Array[Long], Array[Long])]
-      // ... and from the current partition to the rightmost partition
-      for ((cand, freqs) <- it) {
-        leftTotal = (leftTotal, freqs).zipped.map(_ + _)
-        val rightTotal = (bcTotals.value, leftTotal).zipped.map(_ - _)
-        entropyFreqs = (cand, freqs, leftTotal.clone, rightTotal) +: entropyFreqs
-      }        
-      entropyFreqs.iterator
-    })
-
-    // calculate h(S)
-    // s: number of elements
-    // k: number of distinct classes
-    // hs: entropy        
-    val s  = totals.sum
-    val hs = entropy(totals.toSeq, s)
-    val k  = totals.count(_ != 0)
-
-    // select the best threshold according to MDLP
-    val finalCandidates = result.flatMap({
-      case (cand, _, leftFreqs, rightFreqs) =>
-        val k1 = leftFreqs.count(_ != 0)
-        val s1 = if (k1 > 0) leftFreqs.sum else 0
-        val hs1 = entropy(leftFreqs, s1)
-        val k2 = rightFreqs.count(_ != 0)
-        val s2 = if (k2 > 0) rightFreqs.sum else 0
-        val hs2 = entropy(rightFreqs, s2)
-        val weightedHs = (s1 * hs1 + s2 * hs2) / s
-        val gain = hs - weightedHs
-        val delta = log2(math.pow(3, k) - 2) - (k * hs - k1 * hs1 - k2 * hs2)
-        var criterion = (gain - (log2(s - 1) + delta) / s) > stoppingCriterion
-        lastSelected match {
-          case None =>
-          case Some(last) => criterion = criterion && (cand != last)
-        }
-        if (criterion) Seq((weightedHs, cand)) else Seq.empty[(Double, Float)]
-    })
-    // Select among the list of accepted candidate, that with the minimum weightedHs
-    if (finalCandidates.count > 0) Some(finalCandidates.min._2) else None
-  }
-  
-  /**
-   * Compute entropy minimization for candidate points in a range,
-   * and select the best one according to MDLP criterion (sequential version).
-   * 
-   * @param candidates Array of candidate points (point, class histogram).
-   * @param lastSelected last selected threshold.
-   * @param nLabels Number of classes.
-   * @return The minimum-entropy cut point.
-   * 
-   */
-  private def evalThresholds(
-      candidates: Array[(Float, Array[Long])],
-      lastSelected : Option[Float],
-      nLabels: Int): Option[Float] = {
-    
-    // Calculate the total frequencies by label
-    val totals = candidates.map(_._2).reduce((freq1, freq2) => (freq1, freq2).zipped.map(_ + _))
-    
-    // Compute the accumulated frequencies (both left and right) by label
-    var leftAccum = Array.fill(nLabels)(0L)
-    var entropyFreqs = Seq.empty[(Float, Array[Long], Array[Long], Array[Long])]
-    for(i <- candidates.indices) {
-      val (cand, freq) = candidates(i)
-      leftAccum = (leftAccum, freq).zipped.map(_ + _)
-      val rightTotal = (totals, leftAccum).zipped.map(_ - _)
-      entropyFreqs = (cand, freq, leftAccum.clone, rightTotal) +: entropyFreqs
-    }
-
-    // calculate h(S)
-    // s: number of elements
-    // k: number of distinct classes
-    // hs: entropy
-    val s = totals.sum
-    val hs = entropy(totals.toSeq, s)
-    val k = totals.count(_ != 0)
-
-    // select best threshold according to the criteria
-    val finalCandidates = entropyFreqs.flatMap({
-      case (cand, _, leftFreqs, rightFreqs) =>
-        val k1 = leftFreqs.count(_ != 0)
-        val s1 = if (k1 > 0) leftFreqs.sum else 0
-        val hs1 = entropy(leftFreqs, s1)
-        val k2 = rightFreqs.count(_ != 0)
-        val s2 = if (k2 > 0) rightFreqs.sum else 0
-        val hs2 = entropy(rightFreqs, s2)
-        val weightedHs = (s1 * hs1 + s2 * hs2) / s
-        val gain = hs - weightedHs
-        val delta = log2(math.pow(3, k) - 2) - (k * hs - k1 * hs1 - k2 * hs2)
-        var criterion = (gain - (log2(s - 1) + delta) / s) > stoppingCriterion
-        
-        lastSelected match {
-            case None =>
-            case Some(last) => criterion = criterion && (cand != last)
-        }
-
-        if (criterion) Seq((weightedHs, cand)) else Seq.empty[(Double, Float)]
-    })
-    // Select among the list of accepted candidate, that with the minimum weightedHs
-    if (finalCandidates.nonEmpty) Some(finalCandidates.min._2) else None
-  }
- 
   /**
    * Run the entropy minimization discretizer on input data.
    * 
@@ -363,19 +151,19 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint],
     }
     
     // Group elements by feature and point (get distinct points)
-    val nonzeros = featureValues.reduceByKey{ case (v1, v2) => 
+    val nonZeros = featureValues.reduceByKey{ case (v1, v2) =>
       (v1, v2).zipped.map(_ + _)
     }
       
     // Add zero elements for sparse data
-    val zeros = nonzeros
+    val zeros = nonZeros
       .map{case ((k, p), v) => (k, v)}
       .reduceByKey{ case (v1, v2) =>  (v1, v2).zipped.map(_ + _)}
       .map{ case (k, v) => 
         val v2 = for(i <- v.indices) yield bclassDistrib.value(i) - v(i)
         ((k, 0.0F), v2.toArray)
       }.filter{case (_, v) => v.sum > 0}
-    val distinctValues = nonzeros.union(zeros)
+    val distinctValues = nonZeros.union(zeros)
     
     // Sort these values to perform the boundary points evaluation
     val sortedValues = distinctValues.sortByKey()
@@ -403,19 +191,21 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint],
     val bBigIndexes = sc.broadcast(bigIndexes)
       
     // The features with a small number of points can be processed in a parallel way
+    val smallThresholdsFinder = new FewValuesThresholdFinder(nLabels, stoppingCriterion)
     val smallThresholds = initialCandidates
       .filter{case (k, _) => !bBigIndexes.value.contains(k) }
       .groupByKey()
       .mapValues(_.toArray)
-      .mapValues(points => getThresholds(points.toArray.sortBy(_._1), maxBins))
+      .mapValues(points => smallThresholdsFinder.findThresholds(points.sortBy(_._1), maxBins))
     
     // Feature with too many points must be processed iteratively (rare condition)
     logInfo("Number of features that exceed the maximum size per partition: " + 
         bigIndexes.size)
     var bigThresholds = Map.empty[Int, Seq[Float]]
+    val bigThresholdsFinder = new ManyValuesThresholdFinder(nLabels, stoppingCriterion)
     for (k <- bigIndexes.keys){ 
       val cands = initialCandidates.filter{case (k2, _) => k == k2}.values.sortByKey()
-      bigThresholds += ((k, getThresholds(cands, maxBins, elementsByPart)))
+      bigThresholds += ((k, bigThresholdsFinder.findThresholds(cands, maxBins, elementsByPart)))
     }
 
     // Join all thresholds in a single structure
@@ -439,25 +229,8 @@ class MDLPDiscretizer private (val data: RDD[LabeledPoint],
 /** Companion object for static members */
 object MDLPDiscretizer {
 
-  private val LOG2 = math.log(2)
-
-  /** @return log base 2 of x */
-  private val log2 = { x: Double => math.log(x) / LOG2 }
-
   /** The original paper suggested 0 for the stopping criterion, but smaller values like -1e-3 yield more splits */
   private val DEFAULT_STOPPING_CRITERION = 0
-
-  /**
-    * @param freqs sequence of integer frequencies.
-    * @param n the sum of all the frequencies in the list.
-    * @return the total entropy
-    */
-  private def entropy(freqs: Seq[Long], n: Long) = {
-    -freqs.aggregate(0.0)(
-      { case (h, q) => h + (if (q == 0) 0 else (q.toDouble / n) * log2(q.toDouble / n))},
-      { case (h1, h2) => h1 + h2 }
-    )
-  }
 
   /** @return true if f1 and f2 define a boundary */
   private val isBoundary = (f1: Array[Long], f2: Array[Long]) => {

--- a/src/main/scala/org/apache/spark/mllib/feature/ManyValuesThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/ManyValuesThresholdFinder.scala
@@ -71,7 +71,6 @@ class ManyValuesThresholdFinder(nLabels: Int, stoppingCriterion: Double)
     result.sorted :+ Float.PositiveInfinity
   }
 
-
   /**
     * Compute entropy minimization for candidate points in a range,
     * and select the best one according to the MDLP criterion (RDD version).
@@ -112,18 +111,12 @@ class ManyValuesThresholdFinder(nLabels: Int, stoppingCriterion: Double)
       entropyFreqs.iterator
     })
 
-    // calculate h(S)
-    // s: number of elements
-    // k: number of distinct classes
-    // hs: entropy
-    val s  = totals.sum
-    val hs = entropy(totals.toSeq, s)
-    val k  = totals.count(_ != 0)
+    val bucketInfo = new BucketInfo(totals)
 
     // select the best threshold according to MDLP
     val finalCandidates = result.flatMap({
       case (cand, _, leftFreqs, rightFreqs) =>
-        val (criterionValue, weightedHs) = calcCriterionValue(s, hs, k, leftFreqs, rightFreqs)
+        val (criterionValue, weightedHs) = calcCriterionValue(bucketInfo, leftFreqs, rightFreqs)
         var criterion = criterionValue > stoppingCriterion
         lastSelected match {
           case None =>

--- a/src/main/scala/org/apache/spark/mllib/feature/ManyValuesThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/ManyValuesThresholdFinder.scala
@@ -1,0 +1,131 @@
+package org.apache.spark.mllib.feature
+
+import org.apache.spark.rdd.RDD
+
+import scala.collection.mutable
+import FeatureUtils._
+import org.apache.spark.Logging
+
+
+/**
+  * @param nLabels the number of class labels
+  * @param stoppingCriterion influences when to stop recursive splits
+  */
+class ManyValuesThresholdFinder(nLabels: Int, stoppingCriterion: Double) extends Serializable with Logging {
+
+
+  /**
+    * Evaluate boundary points and select the most relevant. This version is used when
+    * the number of candidates exceeds the maximum size per partition (distributed version).
+    *
+    * @param candidates RDD of candidates points (point, class histogram).
+    * @param maxBins Maximum number of points to select
+    * @param elementsByPart Maximum number of elements to evaluate in each partition.
+    * @return Sequence of threshold values.
+    */
+  def findThresholds(candidates: RDD[(Float, Array[Long])],
+                     maxBins: Int,
+                     elementsByPart: Int): Seq[Float] = {
+
+    // Get the number of partitions according to the maximum size established by partition
+    val partitions = { x: Long => math.ceil(x.toFloat / elementsByPart).toInt }
+
+    // Insert the extreme values in the stack (recursive iteration)
+    val stack = new mutable.Queue[((Float, Float), Option[Float])]
+    stack.enqueue(((Float.NegativeInfinity, Float.PositiveInfinity), None))
+    var result = Seq(Float.NegativeInfinity) // # points = # bins - 1
+
+    while (stack.nonEmpty && result.size < maxBins){
+      val (bounds, lastThresh) = stack.dequeue
+      // Filter the candidates between the last limits added to the stack
+      var cands = candidates.filter({ case (th, _) => th > bounds._1 && th < bounds._2 })
+      val nCands = cands.count
+      if (nCands > 0) {
+        cands = cands.coalesce(partitions(nCands))
+        // Selects one threshold among the candidates and returns two partitions to recurse
+        evalThresholds(cands, lastThresh) match {
+          case Some(th) =>
+            result = th +: result
+            stack.enqueue(((bounds._1, th), Some(th)))
+            stack.enqueue(((th, bounds._2), Some(th)))
+          case None => /* criteria not fulfilled, finish! */
+        }
+      }
+    }
+
+    result.sorted :+ Float.PositiveInfinity
+  }
+
+
+  /**
+    * Compute entropy minimization for candidate points in a range,
+    * and select the best one according to the MDLP criterion (RDD version).
+    *
+    * @param candidates RDD of candidate points (point, class histogram).
+    * @param lastSelected Last selected threshold.
+    * @return The minimum-entropy candidate.
+    */
+  private def evalThresholds(
+                              candidates: RDD[(Float, Array[Long])],
+                              lastSelected : Option[Float]) = {
+
+    val sc = candidates.sparkContext
+
+    // Compute the accumulated frequencies by partition
+    val totalsByPart = sc.runJob(candidates, { case it =>
+      val accum = Array.fill(nLabels)(0L)
+      for ((_, freqs) <- it) {for (i <- 0 until nLabels) accum(i) += freqs(i)}
+      accum
+    }: (Iterator[(Float, Array[Long])]) => Array[Long])
+
+    // Compute the total frequency for all partitions
+    var totals = Array.fill(nLabels)(0L)
+    for (t <- totalsByPart) totals = (totals, t).zipped.map(_ + _)
+    val bcTotalsByPart = sc.broadcast(totalsByPart)
+    val bcTotals = sc.broadcast(totals)
+
+    val result = candidates.mapPartitionsWithIndex({ (slice, it) =>
+      // Accumulate frequencies from the left to the current partition
+      var leftTotal = Array.fill(nLabels)(0L)
+      for (i <- 0 until slice) leftTotal = (leftTotal, bcTotalsByPart.value(i)).zipped.map(_ + _)
+      var entropyFreqs = Seq.empty[(Float, Array[Long], Array[Long], Array[Long])]
+      // ... and from the current partition to the rightmost partition
+      for ((cand, freqs) <- it) {
+        leftTotal = (leftTotal, freqs).zipped.map(_ + _)
+        val rightTotal = (bcTotals.value, leftTotal).zipped.map(_ - _)
+        entropyFreqs = (cand, freqs, leftTotal.clone, rightTotal) +: entropyFreqs
+      }
+      entropyFreqs.iterator
+    })
+
+    // calculate h(S)
+    // s: number of elements
+    // k: number of distinct classes
+    // hs: entropy
+    val s  = totals.sum
+    val hs = entropy(totals.toSeq, s)
+    val k  = totals.count(_ != 0)
+
+    // select the best threshold according to MDLP
+    val finalCandidates = result.flatMap({
+      case (cand, _, leftFreqs, rightFreqs) =>
+        val k1 = leftFreqs.count(_ != 0)
+        val s1 = if (k1 > 0) leftFreqs.sum else 0
+        val hs1 = entropy(leftFreqs, s1)
+        val k2 = rightFreqs.count(_ != 0)
+        val s2 = if (k2 > 0) rightFreqs.sum else 0
+        val hs2 = entropy(rightFreqs, s2)
+        val weightedHs = (s1 * hs1 + s2 * hs2) / s
+        val gain = hs - weightedHs
+        val delta = log2(math.pow(3, k) - 2) - (k * hs - k1 * hs1 - k2 * hs2)
+        var criterion = (gain - (log2(s - 1) + delta) / s) > stoppingCriterion
+        lastSelected match {
+          case None =>
+          case Some(last) => criterion = criterion && (cand != last)
+        }
+        if (criterion) Seq((weightedHs, cand)) else Seq.empty[(Double, Float)]
+    })
+    // Select among the list of accepted candidate, that with the minimum weightedHs
+    if (finalCandidates.count > 0) Some(finalCandidates.min._2) else None
+  }
+}

--- a/src/main/scala/org/apache/spark/mllib/feature/ManyValuesThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/ManyValuesThresholdFinder.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.mllib.feature
 
 import org.apache.spark.rdd.RDD

--- a/src/main/scala/org/apache/spark/mllib/feature/ThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/ThresholdFinder.scala
@@ -1,0 +1,41 @@
+package org.apache.spark.mllib.feature
+
+import org.apache.spark.Logging
+
+/**
+  * Base trait for threshold finders.
+  */
+trait ThresholdFinder extends Serializable with Logging {
+
+  private val LOG2 = math.log(2)
+
+  /** @return log base 2 of x */
+  val log2 = { x: Double => math.log(x) / LOG2 }
+
+  /**
+    * @param freqs sequence of integer frequencies.
+    * @param n the sum of all the frequencies in the list.
+    * @return the total entropy
+    */
+  def entropy(freqs: Seq[Long], n: Long) = {
+    -freqs.aggregate(0.0)(
+      { case (h, q) => h + (if (q == 0) 0 else (q.toDouble / n) * log2(q.toDouble / n))},
+      { case (h1, h2) => h1 + h2 }
+    )
+  }
+
+  def calcCriterionValue(s: Double, hs: Double, k: Long,
+                         leftFreqs: Seq[Long], rightFreqs: Seq[Long]): (Double, Double) = {
+    val k1 = leftFreqs.count(_ != 0)
+    val s1 = if (k1 > 0) leftFreqs.sum else 0
+    val hs1 = entropy(leftFreqs, s1)
+    val k2 = rightFreqs.count(_ != 0)
+    val s2 = if (k2 > 0) rightFreqs.sum else 0
+    val hs2 = entropy(rightFreqs, s2)
+    val weightedHs = (s1 * hs1 + s2 * hs2) / s
+    val gain = hs - weightedHs
+    val delta = log2(math.pow(3, k) - 2) - (k * hs - k1 * hs1 - k2 * hs2)
+    (gain - (log2(s - 1) + delta) / s, weightedHs)
+  }
+
+}

--- a/src/main/scala/org/apache/spark/mllib/feature/ThresholdFinder.scala
+++ b/src/main/scala/org/apache/spark/mllib/feature/ThresholdFinder.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.mllib.feature
 
 import org.apache.spark.Logging

--- a/src/test/scala/org/apache/spark/ml/feature/MDLPDiscretizerSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/feature/MDLPDiscretizerSuite.scala
@@ -148,7 +148,7 @@ class MDLPDiscretizerSuite extends FunSuite with BeforeAndAfterAll {
 
     assertResult(
       """-Infinity, Infinity;
-        |-Infinity, 7.1833496, 7.2396, 7.6875, 7.7625, 13.20835, 15.3729, 15.74585, 56.7125, Infinity;
+        |-Infinity, 6.6229, 7.1833496, 7.2396, 7.6875, 7.7625, 13.20835, 15.3729, 15.74585, 56.7125, Infinity;
         |-Infinity, 1.5, 2.5, Infinity;
         |-Infinity, Infinity;
         |-Infinity, Infinity;

--- a/src/test/scala/org/apache/spark/ml/feature/MDLPDiscretizerSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/feature/MDLPDiscretizerSuite.scala
@@ -148,7 +148,7 @@ class MDLPDiscretizerSuite extends FunSuite with BeforeAndAfterAll {
 
     assertResult(
       """-Infinity, Infinity;
-        |-Infinity, 6.6229, 7.1833496, 7.2396, 7.6875, 7.7625, 13.20835, 15.3729, 15.74585, 56.7125, Infinity;
+        |-Infinity, 7.1833496, 7.2396, 7.6875, 7.7625, 13.20835, 15.3729, 15.74585, 56.7125, Infinity;
         |-Infinity, 1.5, 2.5, Infinity;
         |-Infinity, Infinity;
         |-Infinity, Infinity;

--- a/src/test/scala/org/apache/spark/ml/feature/MDLPDiscretizerSuite.scala
+++ b/src/test/scala/org/apache/spark/ml/feature/MDLPDiscretizerSuite.scala
@@ -42,7 +42,7 @@ class MDLPDiscretizerSuite extends FunSuite with BeforeAndAfterAll {
     val df = readCarsData(sqlContext)
     val model = getDiscretizerModel(df, Array("mpg"), "origin", 2)
 
-    assertResult("-Infinity, 16.1, 21.05, Infinity") {
+    assertResult("-Infinity, 21.05, Infinity") {
       model.splits(0).mkString(", ")
     }
   }

--- a/src/test/scala/org/apache/spark/ml/feature/TestHelper.scala
+++ b/src/test/scala/org/apache/spark/ml/feature/TestHelper.scala
@@ -91,6 +91,8 @@ object TestHelper {
     else ISO_DATE_FORMAT.parseDateTime(isoString).getMillis.toString.toDouble
   }
 
+  // label cannot currently have null values - see #8.
+  //private def asString(value: String) = if (value == NULL_VALUE) null else value
   private def asString(value: String) = value
   private def asDouble(value: String) = if (value == NULL_VALUE) Double.NaN else value.toDouble
 


### PR DESCRIPTION
This PR adds the stoppingCriteria param.
Other changes:
  Added ThresholdFinder classes to make it clear that there are two alternative strategies for finding thresholds. Since one used RDDs and the other Arrays, I could not get the api to be the same or make as much code as I wanted in common, but hopefully its an improvement.
I set the version to 0.2-SNAPSHOT in build.scala to prepare for the next release (which I assume is 0.2).
Package is now org.apaphe.spark instead of just org.apache.
