### PR TITLE
DiscretizerModelReader::load fails with Spark 2.1.1 #36

### DIFF
--- a/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
+++ b/src/main/scala/org/apache/spark/ml/feature/MDLPDiscretizer.scala
@@ -258,7 +258,7 @@ object DiscretizerModel extends MLReadable[DiscretizerModel] {
       val Row(splits: Array[Array[Float]]) =
           sqlContext.read.parquet(dataPath)
             .select("splits")
-            .head()
+            .head().getAs[Seq[Seq[Float]]](0).map(arr => arr.toArray).toArray
       val model = new DiscretizerModel(metadata.uid, splits)
       DefaultParamsReader.getAndSetParams(model, metadata)
       model


### PR DESCRIPTION
https://github.com/sramirez/spark-MDLP-discretization/issues/36

Fix to load method for Spark 2.x.x. Since Spark 1.6 is old now, this fix is valid. Has been tested and is working fine. 